### PR TITLE
 markdownify text and normalize_whitespace on all

### DIFF
--- a/assets/tipuesearch/tipuesearch_content.js
+++ b/assets/tipuesearch/tipuesearch_content.js
@@ -4,88 +4,89 @@
 # v1.2
 layout: null
 ---
-{% assign index = "" | split: "" %}
-{% assign excluded_files = site.tipue_search.exclude.files %}
-{% assign excluded_taxonomies = "" | split: "" %}
-{% for tag in site.tipue_search.exclude.tags %}
-  {% assign excluded_taxonomies = excluded_taxonomies | push: tag | uniq %}
-{% endfor %}
-{% for category in site.tipue_search.exclude.categories %}
-  {% assign excluded_taxonomies = excluded_taxonomies | push: category | uniq %}
-{% endfor %}
-{% for post in site.posts %}
-  {% unless post.exclude_from_search == true or excluded_files contains post.path %}
-    {% assign has_excluded_taxonomy = false %}
-    {% for tag in post.tags %}
-      {% if excluded_taxonomies contains tag %}
-        {% assign has_excluded_taxonomy = true %}
-      {% endif %}
-    {% endfor %}
-    {% for category in post.categories %}
-      {% if excluded_taxonomies contains category %}
-        {% assign has_excluded_taxonomy = true %}
-      {% endif %}
-    {% endfor %}
-    {% unless has_excluded_taxonomy == true %}
-      {% assign index = index | push: post | uniq %}
-    {% endunless %}
-  {% endunless %}
-{% endfor %}
-{% if site.tipue_search.include.pages == true %}
-  {% for page in site.html_pages %}
-    {% unless page.exclude_from_search == true or excluded_files contains page.path %}
+{% capture pages %}
+  {% assign index = "" | split: "" %}
+  {% assign excluded_files = site.tipue_search.exclude.files %}
+  {% assign excluded_taxonomies = "" | split: "" %}
+  {% for tag in site.tipue_search.exclude.tags %}
+    {% assign excluded_taxonomies = excluded_taxonomies | push: tag | uniq %}
+  {% endfor %}
+  {% for category in site.tipue_search.exclude.categories %}
+    {% assign excluded_taxonomies = excluded_taxonomies | push: category | uniq %}
+  {% endfor %}
+  {% for post in site.posts %}
+    {% unless post.exclude_from_search == true or excluded_files contains post.path %}
       {% assign has_excluded_taxonomy = false %}
-      {% for tag in page.tags %}
+      {% for tag in post.tags %}
         {% if excluded_taxonomies contains tag %}
           {% assign has_excluded_taxonomy = true %}
         {% endif %}
       {% endfor %}
-      {% for category in page.categories %}
+      {% for category in post.categories %}
         {% if excluded_taxonomies contains category %}
           {% assign has_excluded_taxonomy = true %}
         {% endif %}
       {% endfor %}
       {% unless has_excluded_taxonomy == true %}
-        {% assign index = index | push: page | uniq %}
+        {% assign index = index | push: post | uniq %}
       {% endunless %}
     {% endunless %}
   {% endfor %}
-{% endif %}
-{% for collection in site.tipue_search.include.collections %}
-  {% assign documents = site.documents | where:"collection",collection %}
-  {% for document in documents %}
-    {% unless document.exclude_from_search == true or excluded_files contains document.path %}
-      {% assign has_excluded_taxonomy = false %}
-      {% for tag in document.tags %}
-        {% if excluded_taxonomies contains tag %}
-          {% assign has_excluded_taxonomy = true %}
-        {% endif %}
-      {% endfor %}
-      {% for category in document.categories %}
-        {% if excluded_taxonomies contains category %}
-          {% assign has_excluded_taxonomy = true %}
-        {% endif %}
-      {% endfor %}
-      {% unless has_excluded_taxonomy == true %}
-        {% assign index = index | push: document | uniq %}
+  {% if site.tipue_search.include.pages == true %}
+    {% for page in site.html_pages %}
+      {% unless page.exclude_from_search == true or excluded_files contains page.path %}
+        {% assign has_excluded_taxonomy = false %}
+        {% for tag in page.tags %}
+          {% if excluded_taxonomies contains tag %}
+            {% assign has_excluded_taxonomy = true %}
+          {% endif %}
+        {% endfor %}
+        {% for category in page.categories %}
+          {% if excluded_taxonomies contains category %}
+            {% assign has_excluded_taxonomy = true %}
+          {% endif %}
+        {% endfor %}
+        {% unless has_excluded_taxonomy == true %}
+          {% assign index = index | push: page | uniq %}
+        {% endunless %}
       {% endunless %}
-    {% endunless %}
+    {% endfor %}
+  {% endif %}
+  {% for collection in site.tipue_search.include.collections %}
+    {% assign documents = site.documents | where:"collection",collection %}
+    {% for document in documents %}
+      {% unless document.exclude_from_search == true or excluded_files contains document.path %}
+        {% assign has_excluded_taxonomy = false %}
+        {% for tag in document.tags %}
+          {% if excluded_taxonomies contains tag %}
+            {% assign has_excluded_taxonomy = true %}
+          {% endif %}
+        {% endfor %}
+        {% for category in document.categories %}
+          {% if excluded_taxonomies contains category %}
+            {% assign has_excluded_taxonomy = true %}
+          {% endif %}
+        {% endfor %}
+        {% unless has_excluded_taxonomy == true %}
+          {% assign index = index | push: document | uniq %}
+        {% endunless %}
+      {% endunless %}
+    {% endfor %}
   {% endfor %}
-{% endfor %}
-var tipuesearch = {"pages": [
-{% for document in index %}
-  {% assign taxonomies = "" | split: "" %}
-  {% for tag in document.tags %}
-    {% assign taxonomies = taxonomies | push: tag | uniq %}
+  {% for document in index %}
+    {% assign taxonomies = "" | split: "" %}
+    {% for tag in document.tags %}
+      {% assign taxonomies = taxonomies | push: tag | uniq %}
+    {% endfor %}
+    {% for category in document.categories %}
+      {% assign taxonomies = taxonomies | push: category | uniq %}
+    {% endfor %}
+    {
+      "title": {{ document.title | smartify | strip_html | normalize_whitespace | jsonify }},
+      "text": {{ document.content | markdownify | strip_html | normalize_whitespace | jsonify }},
+      "tags": {{ taxonomies | join: " " | normalize_whitespace | jsonify }},
+      "url": {{ document.url | relative_url | jsonify }}
+    }{% unless forloop.last %},{% endunless %}
   {% endfor %}
-  {% for category in document.categories %}
-    {% assign taxonomies = taxonomies | push: category | uniq %}
-  {% endfor %}
-  {
-    "title": {{ document.title | smartify | strip_html | normalize_whitespace | jsonify }},
-    "text": {{ document.content | strip_html | normalize_whitespace | jsonify }},
-    "tags": {{ taxonomies | join: " " | normalize_whitespace | jsonify }},
-    "url": {{ document.url | relative_url | jsonify }}
-  }{% unless forloop.last %},{% endunless %}
-{% endfor %}
-]};
+{% endcapture %}
+var tipuesearch = {"pages": [ {{ pages | normalize_whitespace }} ]};


### PR DESCRIPTION
The results was showing markdown syntax, then I added the `markdownify` template to convert it to HTML, that continues being converted to text with `strip_html`.

This was my result (See the markdown titles `#`):

![captura de tela de 2017-07-09 12-20-03](https://user-images.githubusercontent.com/3011423/27995324-98583512-64a2-11e7-86d7-321d14763aff.png)

And now, converted (The `#` in the LEMP result is bash comments inside `<pre>`, then it continues visible...):

![captura de tela de 2017-07-09 12-20-22](https://user-images.githubusercontent.com/3011423/27995332-baf0c332-64a2-11e7-960d-1d5a2c07b981.png)

---

Also, now all unnecessary spaces in output is being removed with `normalize_whitespace`. 

With this we can save some bytes.

After:

![captura de tela de 2017-07-09 12-15-55](https://user-images.githubusercontent.com/3011423/27995361-559cca5c-64a3-11e7-8aeb-c6fd4b8a3d7a.png)

Now:

![captura de tela de 2017-07-09 12-16-50](https://user-images.githubusercontent.com/3011423/27995366-634db292-64a3-11e7-9187-d6d7f93424fc.png)






